### PR TITLE
added steps for creating log dir

### DIFF
--- a/docs/manage.rst
+++ b/docs/manage.rst
@@ -117,7 +117,14 @@ Create the application directory
 
 ::
 
-    $ mkdir -p /var/lib/cyclid-ui
+    $ sudo mkdir -p /var/lib/cyclid-ui
+    
+Create the log directory
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    $ sudo mkdir -p /var/log/cyclid-ui/
 
 Configure Unicorn for the Cyclid UI server
 ------------------------------------------

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -183,7 +183,14 @@ Create the application directory
 
 ::
 
-    $ mkdir -p /var/lib/cyclid
+    $ sudo mkdir -p /var/lib/cyclid
+    
+Create the log directory
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    $ sudo mkdir /var/log/cyclid
 
 Configure Unicorn for the Cyclid API server
 -------------------------------------------


### PR DESCRIPTION
When I tried the installation as documented i had following issue:

```
stackadmin@cyclid:~$ sudo unicorn -D -E production -c /var/lib/cyclid-ui/unicorn.rb
/var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/configurator.rb:88:in `block in reload': directory for stderr_path=/var/log/cyclid-ui/unicorn.cyclid-ui.log not writable (ArgumentError)
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/configurator.rb:84:in `each'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/configurator.rb:84:in `reload'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/configurator.rb:65:in `initialize'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/http_server.rb:76:in `new'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/lib/unicorn/http_server.rb:76:in `initialize'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/bin/unicorn:126:in `new'
        from /var/lib/gems/2.3.0/gems/unicorn-5.2.0/bin/unicorn:126:in `<top (required)>'
        from /usr/local/bin/unicorn:22:in `load'
        from /usr/local/bin/unicorn:22:in `<main>'
master failed to start, check stderr log for details
stackadmin@cyclid:~$ sudo mkdir /var/log/cyclid-ui/
stackadmin@cyclid:~$ sudo unicorn -D -E production -c /var/lib/cyclid-ui/unicorn.rb
stackadmin@cyclid:~$
```

Creating the log directories fixed the error and Unicorn started successfully.

Also had to add sudo to create the app directories in /var/lib