### PR TITLE
Release notes & docs

### DIFF
--- a/docs/jobs/environments.rst
+++ b/docs/jobs/environments.rst
@@ -7,7 +7,9 @@ Environments
 The Environment specifies how the build image should be configured for the
 running job. You can specify the operating system and version to use,
 additional software repositories to configure and additional packages to
-install before the job is run.
+install before the job is run. Different Builders & Provisioners may support
+additional options, such as the virtual machine size, or package repository
+keys. 
 
 .. _environment_example:
 
@@ -20,6 +22,7 @@ Example
 
   "environment" : {
     "os" : "ubuntu_14_04",
+    "size" : "small",
     "repos" : [
       {
         "url" : "ppa:brightbox/ruby-ng"
@@ -58,6 +61,27 @@ provide build images and request an ``ubuntu_14_04`` image, the AWS Builder
 may create an instance using the ``ami-1b0d920c`` AMI; but a different Cyclid
 server configured to use LXD for its build images map download the pre-built
 Ubuntu Trusty LXD image.
+
+***************
+Build host size
+***************
+
+===== ====================================================
+Name  Description
+===== ====================================================
+size  Desired build host size
+===== ====================================================
+
+The ``size`` options selects on of five generic build host instance sizes:
+``micro``, ``mini``, ``small``, ``medium`` and ``large``.
+
+The Builder plugin can map these generic sizes to the actual virtual machine
+type. The actual build host configuration may differ between Builders, so
+you should consult the documentation for your :ref:`Builder <builders-plugin>`
+for information on what each generic size means.
+
+This option largely only makes sense for virtual machine Build hosts, and is
+generally ignored for container type Build hosts.
 
 ***************
 Additional data

--- a/docs/plugins/builders.rst
+++ b/docs/plugins/builders.rst
@@ -16,6 +16,29 @@ Google
 The Google Builder plugin creates creates Google Compute Engine (GCE) virtual
 machines build hosts using Google Cloud.
 
+Instance Sizes
+==============
+
+The Google builder maps the generic instance size types to the following Google
+Compute machine types.
+
++--------------+---------------------+
+| Generic Size | Google Machine Type |
++==============+=====================+
+| micro        | f1-micro            |
++--------------+---------------------+
+| mini         | g1-small            |
++--------------+---------------------+
+| small        | n1-standard-1       |
++--------------+---------------------+
+| medium       | n1-standard-2       |
++--------------+---------------------+
+| large        | n1-standard-4       |
++--------------+---------------------+
+
+The default instance size (E.g. if none, or ``default`` is given) is the
+machine type set in the ``machine_type`` configuration option (below).
+
 Configuration
 =============
 

--- a/docs/release_notes/cyclid/0_3.rst
+++ b/docs/release_notes/cyclid/0_3.rst
@@ -10,6 +10,25 @@ Upgrading
 Refer to the standard instructions for :ref:`upgrading <upgrading>` from a
 previous release of Cyclid.
 
+v0.3.2
+======
+
+Highlights
+----------
+
+A small release, mostly intended to add some features required by the hosted
+version of Cyclid.
+
+Changes
+-------
+
+- Allow the job to specificy an instance size (E.g. 'small') and map this to a
+  virtual machine type where it makes sense. Currently this is only supported
+  by the Google Builder.
+- Fix a database connection leak with the Local (Sidekiq based) Dispatcher; it
+  will now ensure all database connections are "checked in" to the pool once
+  the job has finished.
+
 v0.3.1
 ======
 

--- a/docs/release_notes/cyclid_ui/0_2.rst
+++ b/docs/release_notes/cyclid_ui/0_2.rst
@@ -10,6 +10,25 @@ Upgrading
 Refer to the standard instructions for :ref:`upgrading <upgrading>` from a
 previous release of Cyclid.
 
+v0.2.5
+======
+
+Highlights
+----------
+
+A small release, mostly intended to add some features required by the hosted
+version of Cyclid.
+
+Changes
+-------
+
+- Add an API that flushes the caches User object, which can be used to force a
+  refresh whenever the user changes E.g. adding or removing an Organization.
+- Redirect to / on API authentication failure, rather than directly to /login
+- Add a "Catch all" route that redirects unknown locations to /
+- Fix the generated Cyclid Client configuration files.
+- Slight modifications to the session cookies.
+
 v0.2.4
 ======
 


### PR DESCRIPTION
Release notes for Cyclid v0.3.2 & Cyclid-UI v0.2.5
Document the new "size" option for selecting Build host sizes.